### PR TITLE
Add missing include to fix build error (S_IREAD and S_IWRITE undeclared)

### DIFF
--- a/gif_lib.c
+++ b/gif_lib.c
@@ -24,6 +24,7 @@
 #include <stdarg.h>
 
 #include <sys/fcntl.h>
+#include <sys/stat.h>
 
 #include "gif_lib.h"
 


### PR DESCRIPTION
Include sys/stat.h to fix the following error
```
gif_lib.c: In function ‘EGifOpenFileName’:
gif_lib.c:960:15: error: ‘S_IREAD’ undeclared (first use in this function)
  960 |               S_IREAD | S_IWRITE);
      |               ^~~~~~~
gif_lib.c:960:15: note: each undeclared identifier is reported only once for each function it appears in
gif_lib.c:960:25: error: ‘S_IWRITE’ undeclared (first use in this function)
  960 |               S_IREAD | S_IWRITE);
      |                         ^~~~~~~~

```