### PR TITLE
Conditional redefinition of obsolete file access perms

### DIFF
--- a/gif_lib.h
+++ b/gif_lib.h
@@ -49,6 +49,13 @@ extern "C" {
 #define BIGUINT uint32_t
 #endif
 
+#ifndef S_IREAD
+#define S_IREAD S_IRUSR
+#endif
+#ifndef S_IWRITE
+#define S_IWRITE S_IWUSR
+#endif
+
 #define SYM_OFFSETS 0x0000
 #define SYM_LENGTHS 0x1000
 #define SYM_EXTRAS  0x2000


### PR DESCRIPTION
If undefined, redefine the constants `S_IREAD` and `S_IWRITE` as `S_IRUSR` and `S_IWUSR`, used for file access permissions. The former names are only there for compatibility with obsolete BSD systems, as per the [glibc docs](https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html). It seems that this solution was adopted in giflib 5.1.5, or at least I can't find it in 5.1.4.

Resolves #4.